### PR TITLE
Add class selector to transformStyle & backfaceVisibility utilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,19 +296,19 @@ module.exports = function(options = {}) {
     );
 
     const transformStyleUtilities = {
-      'transform-flat': {
+      '.transform-flat': {
         transformStyle: 'flat',
       },
-      'transform-preserve-3d': {
+      '.transform-preserve-3d': {
         transformStyle: 'preserve-3d',
       },
     };
 
     const backfaceVisibilityUtilities = {
-      'backface-visible': {
+      '.backface-visible': {
         backfaceVisibility: 'visible',
       },
-      'backface-hidden': {
+      '.backface-hidden': {
         backfaceVisibility: 'hidden',
       },
     };

--- a/test.js
+++ b/test.js
@@ -440,16 +440,16 @@ test('third-axis translate, scale, and rotate utilities can be generated', () =>
       .perspective-t {
         perspective-origin: top
       }
-      transform-flat {
+      .transform-flat {
         transform-style: flat
       }
-      transform-preserve-3d {
+      .transform-preserve-3d {
         transform-style: preserve-3d
       }
-      backface-visible {
+      .backface-visible {
         backface-visibility: visible
       }
-      backface-hidden {
+      .backface-hidden {
         backface-visibility: hidden
       }
     `);


### PR DESCRIPTION
The `transformStyle` and `backfaceVisibility` utility classes are missing the class selector `.`, was receiving this error:

```
ERROR  in ./assets/css/tailwind.css

Syntax Error: ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/src/index.js):                                                                            friendly-errors 00:39:37
SyntaxError

(121:1) Variant cannot be generated because selector contains no classes.

  119 | }
  120 |
> 121 | @tailwind utilities;
      | ^
  122 |
```